### PR TITLE
fix: zshのfpath堅牢化とasdf.sh廃止対応

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -5,8 +5,14 @@
 # Emacs keybind
 bindkey -e
 
-# fpath
-fpath+=($HOME/.zsh/** /usr/local/share/zsh-completions)
+# fpath（バージョン非依存の安定パスを先頭に。古いFPATH継承への保険）
+fpath=(
+  /opt/homebrew/share/zsh/functions
+  /opt/homebrew/share/zsh/site-functions
+  $HOME/.zsh/**
+  /usr/local/share/zsh-completions
+  $fpath
+)
 
 # COLORTERM
 export COLORTERM=truecolor
@@ -218,7 +224,8 @@ export PATH=${PATH}:/usr/local/opt/coreutils/libexec/gnubin:/usr/local/bin:/usr/
 # direnv
 eval "$(direnv hook zsh)"
 
-. "$(/opt/homebrew/bin/brew --prefix)/opt/asdf/libexec/asdf.sh"
+# asdf (0.16+: asdf.sh は廃止。shims を PATH に追加)
+export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 # Powerline設定 - 動的にパスを解決
 if command -v powerline-config >/dev/null 2>&1; then
     export POWERLINE_CONFIG_COMMAND="powerline-config"


### PR DESCRIPTION
## 背景

`brew upgrade` でzshが `5.9` → `5.9.1` に更新された後、tmux内でのみ大量の `function definition file not found`（compinit / colors / promptinit / is-at-least / add-zsh-hook / bashcompinit）が発生するようになった。

## 原因

**tmuxサーバが古い環境を保持していたことが根本原因。**

- tmuxサーバが `brew upgrade` 前に起動しており、起動時の `FPATH`（`.../Cellar/zsh/5.9/share/zsh/functions` ＝アップグレードで削除済み）をグローバル環境にキャプチャしていた。
- zshは起動時に環境変数 `FPATH` があるとそれで `fpath` を初期化するため、tmuxが生成する各シェルが古い（存在しない）`FPATH` を継承 → `fpath` が無効化 → 標準関数が解決不能。
- gcloud の `complete: command not found`、spaceship の「zsh 5.2 以上が必要」警告はすべて `fpath` 破損の二次被害。
- 付随して `.zshrc` が source していた `asdf.sh` も、asdf 0.19.0（Go版 / 0.16+）で廃止され存在しなくなっていた（別件）。

## 変更内容

- **fpath堅牢化**: バージョン非依存の安定パス（`/opt/homebrew/share/zsh/functions` 等）を `fpath` の先頭に明示。古い `FPATH` を継承しても標準関数が解決でき、今後のzsh更新でも再発しない。
- **asdf.sh廃止対応**: `. asdf.sh` を廃止し、shims を PATH に追加する方式（`export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"`）へ変更。

## 検証

- `zsh -n` 構文チェック: OK
- 古い `FPATH`（5.9）を意図的に注入したクリーン環境でも、安定パスが先頭に補われ compinit / colors / promptinit / add-zsh-hook / is-at-least / bashcompinit がすべて解決することを確認。
- asdf 0.19.0 が動作することを確認。
- tmuxサーバ再起動後、新規ペインでエラーが一切出ないことをユーザーが確認済み。